### PR TITLE
clean up extracted native libraries and tell Git to ignore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build
 
 # Ignore idea files
 .idea
+
+# Ignore extracted native libraries
+examples/*.so
+examples/*.dll

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ build
 .idea
 
 # Ignore extracted native libraries
-examples/*.so
+examples/*.dylib
 examples/*.dll
+examples/*.so

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -46,10 +46,13 @@ dependencies {
 }
 
 // cleanup tasks
-clean.dependsOn('cleanDLLs', 'cleanSOs')
+clean.dependsOn('cleanDLLs', 'cleanDyLibs', 'cleanSOs')
 
 task cleanDLLs(type: Delete) {
     delete fileTree(dir: '.', include: '*.dll')
+}
+task cleanDyLibs(type: Delete) {
+    delete fileTree(dir: '.', include: '*.dylib')
 }
 task cleanSOs(type: Delete) {
     delete fileTree(dir: '.', include: '*.so')

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -44,3 +44,13 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 }
+
+// cleanup tasks
+clean.dependsOn('cleanDLLs', 'cleanSOs')
+
+task cleanDLLs(type: Delete) {
+    delete fileTree(dir: '.', include: '*.dll')
+}
+task cleanSOs(type: Delete) {
+    delete fileTree(dir: '.', include: '*.so')
+}


### PR DESCRIPTION
When the example apps are run, native libraries are extracted and written to the working directory. Git should ignore these files, and `gradle clean` should cause them to be deleted.